### PR TITLE
MIP-9

### DIFF
--- a/test/mip-9/assertCurrentExpectedState.ts
+++ b/test/mip-9/assertCurrentExpectedState.ts
@@ -1,0 +1,41 @@
+import {ethers} from "ethers";
+import {
+    assertDexRewarderRewardsPerSec,
+    assertSTKWellEmissionsPerSecond
+} from "../../src/verification/assertions";
+import BigNumber from "bignumber.js";
+import {ContractBundle} from "@moonwell-fi/moonwell.js";
+import {
+    ECOSYSTEM_RESERVE,
+    SUBMITTER_WALLET,
+    EXPECTED_STARTING_MFAM_HOLDINGS, F_MOVR_GRANT, STARTING_MARKET_REWARDS_STATE
+} from "./vars";
+import {assertCurrentExpectedGovTokenHoldings, assertMarketRewardState} from "../../src";
+
+export async function assertCurrentExpectedState(contracts: ContractBundle, provider: ethers.providers.JsonRpcProvider){
+    console.log("[+] Asserting market configurations are in an expected state")
+
+    await assertCurrentExpectedGovTokenHoldings(
+        contracts,
+        provider,
+        EXPECTED_STARTING_MFAM_HOLDINGS,
+        {ECOSYSTEM_RESERVE, F_MOVR_GRANT, SUBMITTER_WALLET}
+    )
+
+    // Assert current reward speeds
+    await assertDexRewarderRewardsPerSec(contracts, provider,
+        11,
+        22,
+        new BigNumber('5.198326554715510000').times(1e18),
+    )
+
+    // Assert current WELL emissions
+    await assertSTKWellEmissionsPerSecond(contracts, provider,
+        new BigNumber('1.559497966414650000').times(1e18)
+    )
+
+    // Assert current borrow/supply emissions
+    await assertMarketRewardState(
+        contracts, provider, STARTING_MARKET_REWARDS_STATE
+    )
+}

--- a/test/mip-9/assertExpectedEndState.ts
+++ b/test/mip-9/assertExpectedEndState.ts
@@ -1,0 +1,42 @@
+import {ethers} from "ethers";
+import {ContractBundle} from "@moonwell-fi/moonwell.js";
+import {
+    ECOSYSTEM_RESERVE, ENDING_MARKET_REWARDS_STATE, EXPECTED_STARTING_MFAM_HOLDINGS, F_MOVR_GRANT, SENDAMTS
+} from "./vars";
+import {SUBMITTER_WALLET} from "./vars";
+import {
+    assertEndingExpectedGovTokenHoldings,
+    assertMarketRewardState
+} from "../../src";
+import {assertDexRewarderRewardsPerSec, assertSTKWellEmissionsPerSecond} from "../../src/verification/assertions";
+import BigNumber from "bignumber.js";
+
+export async function assertExpectedEndState(contracts: ContractBundle, provider: ethers.providers.JsonRpcProvider){
+    console.log("[+] Asserting protocol is in an expected state AFTER gov proposal passed")
+
+    // Compensate for a rounding issue with reward puller
+    const fixedSendAmts = JSON.parse(JSON.stringify(SENDAMTS))
+    fixedSendAmts['DEX_REWARDER'] -= 1
+
+    await assertEndingExpectedGovTokenHoldings(
+        contracts,
+        provider,
+        EXPECTED_STARTING_MFAM_HOLDINGS,
+        fixedSendAmts,
+        {ECOSYSTEM_RESERVE, F_MOVR_GRANT, SUBMITTER_WALLET}
+    )
+
+    await assertDexRewarderRewardsPerSec(contracts, provider,
+        11,
+        23,
+        new BigNumber('5.284965330627430000').times(1e18),
+    )
+
+    await assertSTKWellEmissionsPerSecond(contracts, provider,
+        new BigNumber('2.536783358701170000').times(1e18)
+    )
+
+    await assertMarketRewardState(
+        contracts, provider, ENDING_MARKET_REWARDS_STATE
+    )
+}

--- a/test/mip-9/generateProposalData.ts
+++ b/test/mip-9/generateProposalData.ts
@@ -45,7 +45,7 @@ export async function generateProposalData(contracts: ContractBundle, provider: 
     )
 
     // Pull in MFAM to the timelock from F-MOVR-GRANT
-    console.log(`    ✅ Sending ${SENDAMTS['DEX_REWARDER']} MFAM to the DEX_REWARDER`)
+    console.log(`    ✅ Sending ${SENDAMTS['DEX_REWARDER']} MFAM to the TIMELOCK`)
     await addProposalToPropData(mfamToken, 'transferFrom',
         [
             F_MOVR_GRANT,

--- a/test/mip-9/generateProposalData.ts
+++ b/test/mip-9/generateProposalData.ts
@@ -1,0 +1,167 @@
+import {ethers} from "ethers";
+import {BigNumber as EthersBigNumber} from "@ethersproject/bignumber/lib/bignumber";
+import {ContractBundle} from "@moonwell-fi/moonwell.js";
+import {addProposalToPropData, REWARD_TYPES} from "../../src";
+import BigNumber from "bignumber.js";
+import {ECOSYSTEM_RESERVE, F_MOVR_GRANT, SENDAMTS, SUBMITTER_WALLET} from "./vars";
+
+export async function generateProposalData(contracts: ContractBundle, provider: ethers.providers.JsonRpcProvider){
+    const mantissa = EthersBigNumber.from(10).pow(18)
+
+    const proposalData: any = {
+        targets: [],
+        values: [],
+        signatures: [],
+        callDatas: [],
+    }
+
+    console.log("[+] Constructing Proposal...")
+
+    const mfamToken = contracts.GOV_TOKEN.contract.connect(provider)
+    const stkMFAM = contracts.SAFETY_MODULE.contract.connect(provider)
+    const comptroller = contracts.COMPTROLLER.contract.connect(provider)
+    const dexRewarder = contracts.DEX_REWARDER.contract.connect(provider)
+
+    // Send MFAM from F-MOVR-GRANT to ECOSYSTEM_RESERVE
+    console.log(`    ✅ Sending ${SENDAMTS['ECOSYSTEM_RESERVE']} MFAM to the ECOSYSTEM_RESERVE`)
+    await addProposalToPropData(mfamToken, 'transferFrom',
+        [
+            F_MOVR_GRANT,
+            ECOSYSTEM_RESERVE,
+            EthersBigNumber.from(SENDAMTS['ECOSYSTEM_RESERVE']).mul(mantissa)
+        ],
+        proposalData
+    )
+
+    // Send MFAM from F-MOVR-GRANT to comptroller (unitroller)
+    console.log(`    ✅ Sending ${SENDAMTS['COMPTROLLER']} MFAM to the COMPTROLLER`)
+    await addProposalToPropData(mfamToken, 'transferFrom',
+        [
+            F_MOVR_GRANT,
+            contracts.COMPTROLLER.address,
+            EthersBigNumber.from(SENDAMTS["COMPTROLLER"]).mul(mantissa)
+        ],
+        proposalData
+    )
+
+    // Pull in MFAM to the timelock from F-MOVR-GRANT
+    console.log(`    ✅ Sending ${SENDAMTS['DEX_REWARDER']} MFAM to the DEX_REWARDER`)
+    await addProposalToPropData(mfamToken, 'transferFrom',
+        [
+            F_MOVR_GRANT,
+            contracts.TIMELOCK!.address,
+            EthersBigNumber.from(SENDAMTS['DEX_REWARDER']).mul(mantissa)
+        ],
+        proposalData
+    )
+
+    // Approve dexRewarder to pull MFAM from the timelock
+    console.log(`    ✅ Approving ${SENDAMTS['DEX_REWARDER']} for the DEX REWARDER from the TIMELOCK`)
+    await addProposalToPropData(mfamToken, 'approve',
+        [
+            contracts.DEX_REWARDER.address,
+            EthersBigNumber.from(SENDAMTS['DEX_REWARDER']).mul(mantissa)
+        ],
+        proposalData
+    )
+
+    // Configure dexRewarder/trigger pulling the WELL rewards
+    console.log(`    ✅ Adding reward info to DEX REWARDER`)
+    await addProposalToPropData(dexRewarder, 'addRewardInfo',
+        [
+            11,
+            new Date("2023-01-27T03:30:00.000Z").getTime() / 1000, // == 1674790200
+            EthersBigNumber.from(
+                new BigNumber('5.284965330627430000').times(1e18).toFixed()
+            )
+        ],
+        proposalData
+    )
+
+    // Configure new reward speeds for stkMFAM
+    console.log(`    ✅ Adjust stkMFAM emissions`)
+    await addProposalToPropData(stkMFAM, 'configureAsset',
+        [
+            EthersBigNumber.from(new BigNumber('2.536783358701170000').times(1e18).toFixed()),
+            stkMFAM.address
+        ],
+        proposalData
+    )
+
+    // Configure reward speeds for MOVR
+    await addProposalToPropData(comptroller, '_setRewardSpeed',
+        [
+            EthersBigNumber.from(REWARD_TYPES.NATIVE), // 0 = MFAM, 1 = MOVR
+            contracts.MARKETS['MOVR'].mTokenAddress,
+            EthersBigNumber.from(new BigNumber('0.000320034722222222').times(1e18).toFixed()),
+            EthersBigNumber.from(new BigNumber('0.000746747685185185').times(1e18).toFixed()),
+        ],
+        proposalData
+    )
+
+    // Configure reward speeds for xcKSM
+    await addProposalToPropData(comptroller, '_setRewardSpeed',
+        [
+            EthersBigNumber.from(REWARD_TYPES.NATIVE), // 0 = MFAM, 1 = MOVR
+            contracts.MARKETS['xcKSM'].mTokenAddress,
+            EthersBigNumber.from(new BigNumber('0.000328240740740741').times(1e18).toFixed()),
+            EthersBigNumber.from(new BigNumber('0.000328240740740741').times(1e18).toFixed()),
+        ],
+        proposalData
+    )
+
+    // Configure reward speeds for ETH.multi
+    await addProposalToPropData(comptroller, '_setRewardSpeed',
+        [
+            EthersBigNumber.from(REWARD_TYPES.NATIVE), // 0 = MFAM, 1 = MOVR
+            contracts.MARKETS['ETH.multi'].mTokenAddress,
+            EthersBigNumber.from(new BigNumber('0.000344652777777778').times(1e18).toFixed()),
+            EthersBigNumber.from(new BigNumber('0.000804189814814815').times(1e18).toFixed()),
+        ],
+        proposalData
+    )
+
+    // Configure reward speeds for USDC.multi
+    await addProposalToPropData(comptroller, '_setRewardSpeed',
+        [
+            EthersBigNumber.from(REWARD_TYPES.NATIVE), // 0 = MFAM, 1 = MOVR
+            contracts.MARKETS['USDC.multi'].mTokenAddress,
+            EthersBigNumber.from(new BigNumber('0.000861631944444445').times(1e18).toFixed()),
+            EthersBigNumber.from(new BigNumber('0.002010474537037040').times(1e18).toFixed()),
+        ],
+        proposalData
+    )
+
+    // Configure reward speeds for USDT.multi
+    await addProposalToPropData(comptroller, '_setRewardSpeed',
+        [
+            EthersBigNumber.from(REWARD_TYPES.NATIVE), // 0 = MFAM, 1 = MOVR
+            contracts.MARKETS['USDT.multi'].mTokenAddress,
+            EthersBigNumber.from(new BigNumber('0.000246180555555556').times(1e18).toFixed()),
+            EthersBigNumber.from(new BigNumber('0.000574421296296296').times(1e18).toFixed()),
+        ],
+        proposalData
+    )
+
+    // Configure reward speeds for FRAX
+    await addProposalToPropData(comptroller, '_setRewardSpeed',
+        [
+            EthersBigNumber.from(REWARD_TYPES.NATIVE), // 0 = MFAM, 1 = MOVR
+            contracts.MARKETS['FRAX'].mTokenAddress,
+            EthersBigNumber.from(new BigNumber('0.000492361111111111').times(1e18).toFixed()),
+            EthersBigNumber.from(new BigNumber('0.001148842592592590').times(1e18).toFixed()),
+        ],
+        proposalData
+    )
+
+    await addProposalToPropData(mfamToken, 'transferFrom',
+        [
+            F_MOVR_GRANT,
+            SUBMITTER_WALLET,
+            EthersBigNumber.from(SENDAMTS['SUBMITTER_WALLET']).mul(mantissa)
+        ],
+        proposalData
+    )
+
+    return proposalData
+}

--- a/test/mip-9/mip-9-verification.ts
+++ b/test/mip-9/mip-9-verification.ts
@@ -1,0 +1,57 @@
+import {ethers} from 'ethers'
+import {
+    passGovProposal,
+    setupDeployerAndEnvForGovernance,
+    sleep,
+    startGanache
+} from "../../src";
+
+import {Contracts} from '@moonwell-fi/moonwell.js'
+import {generateProposalData} from "./generateProposalData";
+import {assertCurrentExpectedState} from "./assertCurrentExpectedState";
+import {assertExpectedEndState} from "./assertExpectedEndState";
+import {F_MOVR_GRANT, SUBMITTER_WALLET} from "./vars";
+
+const FORK_BLOCK = 3036100
+
+test("mip-9-verifications", async () => {
+
+    const contracts = Contracts.moonriver
+
+    const forkedChainProcess = await startGanache(contracts,
+        FORK_BLOCK,
+        'https://rpc.api.moonriver.moonbeam.network',
+        [F_MOVR_GRANT, SUBMITTER_WALLET]
+    )
+
+    console.log("Waiting 5 seconds for chain to bootstrap...")
+    await sleep(5)
+
+    try {
+        const provider = new ethers.providers.JsonRpcProvider('http://127.0.0.1:8545')
+
+        await setupDeployerAndEnvForGovernance(
+            contracts,
+            provider,
+            F_MOVR_GRANT,
+            FORK_BLOCK,
+            1_583_312 // Quorum adjusts up just short of this amount when the proposal is submitted
+        )
+
+        await assertCurrentExpectedState(contracts, provider)
+
+        // Generate new proposal data
+        const proposalData = await generateProposalData(contracts, provider)
+
+        // Pass the proposal
+        await passGovProposal(contracts, provider, proposalData)
+
+        // Assert that our end state is as desired
+        await assertExpectedEndState(contracts, provider)
+    } finally {
+        // Kill our child chain.
+        console.log("Shutting down Ganache chain. PID", forkedChainProcess.pid!)
+        process.kill(-forkedChainProcess.pid!)
+        console.log("Ganache chain stopped.")
+    }
+});

--- a/test/mip-9/vars.ts
+++ b/test/mip-9/vars.ts
@@ -1,0 +1,104 @@
+import {MarketRewardMap, REWARD_TYPES} from "../../src";
+import BigNumber from "bignumber.js";
+
+export const F_MOVR_GRANT = '0x45DD368E30C07804b037260071d332e547C874F0'
+export const ECOSYSTEM_RESERVE = '0xbA17581Bb6d89954B42fB84294e476e97588908B'
+
+export const SUBMITTER_WALLET = '0x87E1e08eDAfD16346d8328e2CF260ff8Bdad9e84'
+
+export const EXPECTED_STARTING_MFAM_HOLDINGS = {
+    F_MOVR_GRANT:  274_273_076,
+    SUBMITTER_WALLET: 0,
+    ECOSYSTEM_RESERVE: 5_372_549,
+    COMPTROLLER: 6_440_210,
+    DEX_REWARDER: 8_666_069,
+}
+
+export const SENDAMTS = {
+    ECOSYSTEM_RESERVE: 12_273_973,
+    COMPTROLLER: 15_640_000,
+    DEX_REWARDER: 25_570_777,
+    SUBMITTER_WALLET: 100_000,
+}
+
+SENDAMTS['F_MOVR_GRANT'] = -1 * (
+    SENDAMTS['ECOSYSTEM_RESERVE'] + SENDAMTS['COMPTROLLER'] + SENDAMTS['DEX_REWARDER'] + SENDAMTS['SUBMITTER_WALLET']
+)
+
+export const STARTING_MARKET_REWARDS_STATE : MarketRewardMap = {
+    'MOVR': {
+        [REWARD_TYPES.NATIVE]: {
+            expectedSupply: new BigNumber("0.000384041666666667").times(1e18),
+            expectedBorrow: new BigNumber("0.000896097222222222").times(1e18),
+        },
+    },
+    'xcKSM': {
+        [REWARD_TYPES.NATIVE]: {
+            expectedSupply: new BigNumber("0.000393888888888889").times(1e18),
+            expectedBorrow: new BigNumber("0.000393888888888889").times(1e18),
+        },
+    },
+    'ETH.multi': {
+        [REWARD_TYPES.NATIVE]: {
+            expectedSupply: new BigNumber("0.000413583333333333").times(1e18),
+            expectedBorrow: new BigNumber("0.000965027777777778").times(1e18),
+        },
+    },
+    'USDC.multi': {
+        [REWARD_TYPES.NATIVE]: {
+            expectedSupply: new BigNumber("0.001033958333333330").times(1e18),
+            expectedBorrow: new BigNumber("0.002412569444444440").times(1e18),
+        },
+    },
+    'USDT.multi': {
+        [REWARD_TYPES.NATIVE]: {
+            expectedSupply: new BigNumber("0.000295416666666667").times(1e18),
+            expectedBorrow: new BigNumber("0.000689305555555556").times(1e18),
+        },
+    },
+    'FRAX': {
+        [REWARD_TYPES.NATIVE]: {
+            expectedSupply: new BigNumber("0.000590833333333333").times(1e18),
+            expectedBorrow: new BigNumber("0.001378611111111110").times(1e18),
+        },
+    },
+}
+
+export const ENDING_MARKET_REWARDS_STATE : MarketRewardMap = {
+    'MOVR': {
+        [REWARD_TYPES.NATIVE]: {
+            expectedSupply: new BigNumber("0.000320034722222222").times(1e18),
+            expectedBorrow: new BigNumber("0.000746747685185185").times(1e18),
+        },
+    },
+    'xcKSM': {
+        [REWARD_TYPES.NATIVE]: {
+            expectedSupply: new BigNumber("0.000328240740740741").times(1e18),
+            expectedBorrow: new BigNumber("0.000328240740740741").times(1e18),
+        },
+    },
+    'ETH.multi': {
+        [REWARD_TYPES.NATIVE]: {
+            expectedSupply: new BigNumber("0.000344652777777778").times(1e18),
+            expectedBorrow: new BigNumber("0.000804189814814815").times(1e18),
+        },
+    },
+    'USDC.multi': {
+        [REWARD_TYPES.NATIVE]: {
+            expectedSupply: new BigNumber("0.000861631944444445").times(1e18),
+            expectedBorrow: new BigNumber("0.002010474537037040").times(1e18),
+        },
+    },
+    'USDT.multi': {
+        [REWARD_TYPES.NATIVE]: {
+            expectedSupply: new BigNumber("0.000246180555555556").times(1e18),
+            expectedBorrow: new BigNumber("0.000574421296296296").times(1e18),
+        },
+    },
+    'FRAX': {
+        [REWARD_TYPES.NATIVE]: {
+            expectedSupply: new BigNumber("0.000492361111111111").times(1e18),
+            expectedBorrow: new BigNumber("0.001148842592592590").times(1e18),
+        },
+    },
+}


### PR DESCRIPTION
Also makes a couple tweaks, namely adding a `bufferAmount` to `setupDeployerAndEnvForGovernance` since with a floating quorum `getQuorum()` doesn't return the next value to be used. This way we can manually pad things to what quorum adjusts to after the fact and still have enough voting power to pass the generated proposal. 

Other than that it's a verification that should cover everything. A copy of the output can be found here: https://gist.github.com/moonwell-octavius/f6160608e615f90dc42caae82277f29d