### PR TITLE
Refactor Market Deployer to Prove Multiple Deploys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
-        "@moonwell-fi/market-deployer": "^0.1.0",
+        "@moonwell-fi/market-deployer": "^0.2.0",
         "@moonwell-fi/moonwell.js": "^0.2.3",
         "bignumber.js": "^9.1.0",
         "ethers": "^5.7.1"
@@ -1640,9 +1640,9 @@
       }
     },
     "node_modules/@moonwell-fi/market-deployer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@moonwell-fi/market-deployer/-/market-deployer-0.1.0.tgz",
-      "integrity": "sha512-pQQB3s372TQW/vcidbJ9/52tlgVcN4Crj4GNwpzPTGGifak3FYnI9+fYrAAdbsdJGoqtEDbVPnB3RYHKGFUGIw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@moonwell-fi/market-deployer/-/market-deployer-0.2.0.tgz",
+      "integrity": "sha512-Im0x5nwRZCQ9xuDBb0MskhUSb/kGHNluQJUXJLMAa9A///SliKjnJdJSrG/BfhYiS5PwwRj4DeAmEQ8BtTBsXQ==",
       "dependencies": {
         "@moonwell-fi/moonwell.js": "^0.2.3",
         "@types/node": "^18.7.18",
@@ -5806,9 +5806,9 @@
       }
     },
     "@moonwell-fi/market-deployer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@moonwell-fi/market-deployer/-/market-deployer-0.1.0.tgz",
-      "integrity": "sha512-pQQB3s372TQW/vcidbJ9/52tlgVcN4Crj4GNwpzPTGGifak3FYnI9+fYrAAdbsdJGoqtEDbVPnB3RYHKGFUGIw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@moonwell-fi/market-deployer/-/market-deployer-0.2.0.tgz",
+      "integrity": "sha512-Im0x5nwRZCQ9xuDBb0MskhUSb/kGHNluQJUXJLMAa9A///SliKjnJdJSrG/BfhYiS5PwwRj4DeAmEQ8BtTBsXQ==",
       "requires": {
         "@moonwell-fi/moonwell.js": "^0.2.3",
         "@types/node": "^18.7.18",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
-    "@moonwell-fi/market-deployer": "^0.1.0",
+    "@moonwell-fi/market-deployer": "^0.2.0",
     "@moonwell-fi/moonwell.js": "^0.2.3",
     "bignumber.js": "^9.1.0",
     "ethers": "^5.7.1"

--- a/test/market-deployer/assertCurrentExpectedState.ts
+++ b/test/market-deployer/assertCurrentExpectedState.ts
@@ -6,13 +6,25 @@ import {
 
 import {ContractBundle} from "@moonwell-fi/moonwell.js";
 
+// TODO: Refactor this somewhere global to use in a MIP.
+async function assertExpectedStateForToken(
+  provider: ethers.providers.JsonRpcProvider,
+  contracts: ContractBundle,
+  token: string,
+  chainlinkFeedForToken: string
+) {
+  console.log(`[+] Asserting market for ${token} does not exist`)
+  await assertMarketIsNotListed(provider, contracts, token)
+  await assertChainlinkFeedIsNotRegistered(provider, contracts, chainlinkFeedForToken)
+}
+
 export async function assertCurrentExpectedState(
   provider: ethers.providers.JsonRpcProvider, 
   contracts: ContractBundle, 
-  tokenToList: string, 
-  chainlinkFeedForToken: string
+  tokensToList: Array<string>, 
+  chainlinkFeedsForTokens: Array<string>
 ){
-    console.log("[+] Asserting market does not exist")
-    await assertMarketIsNotListed(provider, contracts, tokenToList)
-    await assertChainlinkFeedIsNotRegistered(provider, contracts, chainlinkFeedForToken)
+  for (let i = 0; i < tokensToList.length; i++) {
+    await assertExpectedStateForToken(provider, contracts, tokensToList[i], chainlinkFeedsForTokens[i])
+  }
 }

--- a/test/market-deployer/assertExpectedEndState.ts
+++ b/test/market-deployer/assertExpectedEndState.ts
@@ -16,9 +16,10 @@ import {
 import {ContractBundle, getContract} from "@moonwell-fi/moonwell.js";
 import BigNumber from "bignumber.js";
 
-export async function assertExpectedEndState(
+// TODO: Refactor this somewhere global to use in a MIP.
+async function assertExpectedStateEndStateForToken(
   provider: ethers.providers.JsonRpcProvider,
-  contracts: ContractBundle, 
+  contracts: ContractBundle,
   tokenAddress: string,
   chainlinkFeedAddress: string,
   tokenSymbol: string,
@@ -28,39 +29,71 @@ export async function assertExpectedEndState(
   protocolSeizeSharePercent: number,
   collateralFactorPercent: number,
   expectedMarketAddress: string
-){
-    console.log("[+] Asserting protocol is in an expected state AFTER gov proposal passed")
+) {
+  console.log(`[+] Asserting protocol is in an expected for ${tokenSymbol} state AFTER gov proposal passed`)
 
-    // Market has the expected values in storage.
-    const market = getContract('MErc20Delegator', expectedMarketAddress, provider)
-    await assertStorageAddress(market, tokenAddress, 'underlying')
-    await assertStorageAddress(market, contracts.COMPTROLLER.address, 'comptroller')
-    await assertStorageAddress(market, contracts.INTEREST_RATE_MODEL.address, 'interestRateModel')
-    await assertStorageAddress(market, ethers.constants.AddressZero, 'pendingAdmin')
-    await assertStorageString(market, mTokenName, 'name')
-    await assertStorageString(market, mTokenSymbol, 'symbol')
+  // Market has the expected values in storage.
+  const market = getContract('MErc20Delegator', expectedMarketAddress, provider)
+  await assertStorageAddress(market, tokenAddress, 'underlying')
+  await assertStorageAddress(market, contracts.COMPTROLLER.address, 'comptroller')
+  await assertStorageAddress(market, contracts.INTEREST_RATE_MODEL.address, 'interestRateModel')
+  await assertStorageAddress(market, ethers.constants.AddressZero, 'pendingAdmin')
+  await assertStorageString(market, mTokenName, 'name')
+  await assertStorageString(market, mTokenSymbol, 'symbol')
 
-    // Economic parameters on market are correct
-    await assertMarketRF(provider, expectedMarketAddress, reserveFactoryPercent)
-    await assertMarketSeizeShare(provider, expectedMarketAddress, protocolSeizeSharePercent)
+  // Economic parameters on market are correct
+  await assertMarketRF(provider, expectedMarketAddress, reserveFactoryPercent)
+  await assertMarketSeizeShare(provider, expectedMarketAddress, protocolSeizeSharePercent)
 
-    // Market is admin'ed correctly by the timelock.
-    await assertTimelockIsAdminOfMarket(provider, contracts, expectedMarketAddress)
+  // Market is admin'ed correctly by the timelock.
+  await assertTimelockIsAdminOfMarket(provider, contracts, expectedMarketAddress)
 
-    // Unitroller has the market listed with the correct collateral factor
-    await assertMarketIsListed(provider, contracts, tokenAddress, expectedMarketAddress)
-    await assertCF(provider, contracts, expectedMarketAddress, collateralFactorPercent)
-    
-    // Assert a chain link feed is registered
-    await assertChainlinkFeedIsRegistered(provider, contracts, tokenSymbol, chainlinkFeedAddress)
+  // Unitroller has the market listed with the correct collateral factor
+  await assertMarketIsListed(provider, contracts, tokenAddress, expectedMarketAddress)
+  await assertCF(provider, contracts, expectedMarketAddress, collateralFactorPercent)
 
-    // Assertions about the contract: we are talking to a contract with known bytecode and it's pointed at a known impl
-    await assertMTokenProxySetCorrectly(provider, contracts, expectedMarketAddress)
-    await assertMTokenProxyByteCodeMatches(provider, expectedMarketAddress)
+  // Assert a chain link feed is registered
+  await assertChainlinkFeedIsRegistered(provider, contracts, tokenSymbol, chainlinkFeedAddress)
 
-    // Assert no supply speeds, and a very slow borrow speed.
-    const expectedBorrowSpeed = new BigNumber(1)
-    const expectedSupplySpeed = new BigNumber(0)
-    await assertMarketNativeTokenRewardSpeed(contracts, provider, tokenSymbol, expectedSupplySpeed, expectedBorrowSpeed)
-    await assertMarketGovTokenRewardSpeed(contracts, provider, tokenSymbol, expectedSupplySpeed, expectedBorrowSpeed)
+  // Assertions about the contract: we are talking to a contract with known bytecode and it's pointed at a known impl
+  await assertMTokenProxySetCorrectly(provider, contracts, expectedMarketAddress)
+  await assertMTokenProxyByteCodeMatches(provider, expectedMarketAddress)
+
+  // Assert no supply speeds, and a very slow borrow speed.
+  const expectedBorrowSpeed = new BigNumber(1)
+  const expectedSupplySpeed = new BigNumber(0)
+  await assertMarketNativeTokenRewardSpeed(contracts, provider, tokenSymbol, expectedSupplySpeed, expectedBorrowSpeed)
+  await assertMarketGovTokenRewardSpeed(contracts, provider, tokenSymbol, expectedSupplySpeed, expectedBorrowSpeed)
+
+  console.log()
+}
+
+export async function assertExpectedEndState(
+  provider: ethers.providers.JsonRpcProvider,
+  contracts: ContractBundle,
+  tokenAddresses: Array<string>,
+  chainlinkFeedAddresses: Array<string>,
+  tokenSymbols: Array<string>,
+  mTokenNames: Array<string>,
+  mTokenSymbols: Array<string>,
+  reserveFactoryPercents: Array<number>,
+  protocolSeizeSharePercents: Array<number>,
+  collateralFactorPercents: Array<number>,
+  expectedMarketAddresses: Array<string>
+) {
+  for (let i = 0; i < tokenAddresses.length; i++) {
+    await assertExpectedStateEndStateForToken(
+      provider,
+      contracts,
+      tokenAddresses[i],
+      chainlinkFeedAddresses[i],
+      tokenSymbols[i],
+      mTokenNames[i],
+      mTokenSymbols[i],
+      reserveFactoryPercents[i],
+      protocolSeizeSharePercents[i],
+      collateralFactorPercents[i],
+      expectedMarketAddresses[i]
+    )
+  }
 }

--- a/test/market-deployer/generateProposalData.ts
+++ b/test/market-deployer/generateProposalData.ts
@@ -1,17 +1,18 @@
 import { deployAndWireMarket } from '@moonwell-fi/market-deployer'
+import MarketConfiguration from '@moonwell-fi/market-deployer/dist/types/market-configuration';
 import { Environment } from '@moonwell-fi/moonwell.js';
 
 export const generateProposalData = async (
   deployer: any,
-  tokenAddress: string,
-  chainlinkFeedAddress: string,
-  tokenSymbol: string,
-  tokenDecimals: number,
-  mTokenName: string,
-  mTokenSymbol: string,
-  reserveFactoryPercent: number,
-  protocolSeizeSharePercent: number,
-  collateralFactorPercent: number,
+  tokenAddresses: Array<string>,
+  chainlinkFeedAddresses: Array<string>,
+  tokenSymbols: Array<string>,
+  tokenDecimals: Array<number>,
+  mTokenNames: Array<string>,
+  mTokenSymbols: Array<string>,
+  reserveFactoryPercents: Array<number>,
+  protocolSeizeSharePercents: Array<number>,
+  collateralFactorPercents: Array<number>,
 ) => {
   console.log("[+] Deploying Market ")
 
@@ -19,26 +20,34 @@ export const generateProposalData = async (
     networkName: 'moonbeam',
     environment: Environment.MOONBEAM,
     deployer,
-    requiredConfirmations: 1
+    requiredConfirmations: 1,
+    numMarkets: tokenAddresses.length
   }
-  const marketConfiguration = {
-    tokenAddress,
-    chainlinkFeedAddress,
-    tokenSymbol,
-    tokenDecimals,
-    mTokenName,
-    mTokenSymbol,
-    reserveFactor: reserveFactoryPercent,
-    protocolSeizeShare: protocolSeizeSharePercent,
-    collateralFactor: collateralFactorPercent
+  const marketConfigurations: Array<MarketConfiguration> = []
+  for (let i = 0; i < tokenAddresses.length; i++) {
+    marketConfigurations.push(
+      {
+        tokenAddress: tokenAddresses[i],
+        chainlinkFeedAddress: chainlinkFeedAddresses[i],
+        tokenSymbol: tokenSymbols[i],
+        tokenDecimals: tokenDecimals[i],
+        mTokenName: mTokenNames[i],
+        mTokenSymbol: mTokenSymbols[i],
+        reserveFactor: reserveFactoryPercents[i],
+        protocolSeizeShare: protocolSeizeSharePercents[i],
+        collateralFactor: collateralFactorPercents[i]
+      }
+    )
   }
 
-  const { govProposal, mTokenDeployResult } = await deployAndWireMarket(
-    marketConfiguration,
+  const { proposal, mTokenDeployResults } = await deployAndWireMarket(
+    marketConfigurations,
     deploymentConfiguration
   )
 
-  console.log(`    ✅ Market deployed at ${mTokenDeployResult.contractAddress}.`)
+  for (let i = 0; i < mTokenDeployResults.length; i++) {
+  console.log(`    ✅ Market deployed at ${mTokenDeployResults[i].contractAddress}.`)
+  }
 
-  return { govProposal, mTokenDeployResult}
+  return { proposal, mTokenDeployResults}
 }

--- a/test/market-deployer/market-verification.ts
+++ b/test/market-deployer/market-verification.ts
@@ -10,7 +10,7 @@ const wellTreasuryAddress = "0x519ee031E182D3E941549E7909C9319cFf4be69a";
 
 const FORK_BLOCK = 1757073
 
-test("market-deployer", async () => {
+test("market-deployer with a single market", async () => {
   const contracts = Contracts.moonbeam
 
   const fGLMRLM = '0x6972f25AB3FC425EaF719721f0EBD1Cdb58eE451'
@@ -27,15 +27,15 @@ test("market-deployer", async () => {
   await sleep(5)
 
   try {
-        const tokenToList = "0x27292cf0016e5df1d8b37306b2a98588acbd6fca" // axlATOM
-        const chainlinkAddress = "0x4F152D143c97B5e8d2293bc5B2380600f274a5dd" // ATOM
-        const tokenSymbol = "axlATOM"
-        const tokenDecimals =  6
-        const mTokenName = "Moonwell axlATOM"
-        const mTokenSymbol = "maxlATOM"
-        const reserveFactorPercent = 60
-        const protocolSeizeSharePercent = 10
-        const collateralFactorPercent = 40
+        const tokensToList = ["0x27292cf0016e5df1d8b37306b2a98588acbd6fca"] // axlATOM
+        const chainlinkAddresses = ["0x4F152D143c97B5e8d2293bc5B2380600f274a5dd"] // ATOM
+        const tokenSymbols = ["axlATOM"]
+        const tokenDecimals = [6]
+        const mTokenNames = ["Moonwell axlATOM"]
+        const mTokenSymbols = ["maxlATOM"]
+        const reserveFactorPercents = [60]
+        const protocolSeizeSharePercents = [10]
+        const collateralFactorPercents = [40]
 
         const provider = new ethers.providers.JsonRpcProvider('http://127.0.0.1:8545')
 
@@ -43,40 +43,128 @@ test("market-deployer", async () => {
         await setupDeployerAndEnvForGovernance(contracts, provider, wellTreasuryAddress, FORK_BLOCK)
 
         // Assert that a market is not listed for the token and a chainlink feed is not registered.
-        await assertCurrentExpectedState(provider, contracts, tokenToList, chainlinkAddress)
+        await assertCurrentExpectedState(provider, contracts, tokensToList, chainlinkAddresses)
 
         // Generate proposal data
         const deployer = await provider.getSigner(0)
-        const {govProposal, mTokenDeployResult} = await generateProposalData(
+        const {proposal, mTokenDeployResults} = await generateProposalData(
           deployer,
-          tokenToList,
-          chainlinkAddress,
-          tokenSymbol,
+          tokensToList,
+          chainlinkAddresses,
+          tokenSymbols,
           tokenDecimals,
-          mTokenName,
-          mTokenSymbol,
-          reserveFactorPercent,
-          protocolSeizeSharePercent,
-          collateralFactorPercent,
+          mTokenNames,
+          mTokenSymbols,
+          reserveFactorPercents,
+          protocolSeizeSharePercents,
+          collateralFactorPercents,
         )
 
         // Pass the proposal
-        await passGovProposal(contracts, provider, govProposal)
+        await passGovProposal(contracts, provider, proposal)
 
         // Assert the market is correctly admin'ed, with the right economic parameters and has the right storage set.
         // Assert that a chainlink feed has been registered.
         await assertExpectedEndState(
           provider,
           contracts, 
-          tokenToList,
-          chainlinkAddress,
-          tokenSymbol,
-          mTokenName,
-          mTokenSymbol,
-          reserveFactorPercent,
-          protocolSeizeSharePercent,
-          collateralFactorPercent,
-          mTokenDeployResult.contractAddress,
+          tokensToList,
+          chainlinkAddresses,
+          tokenSymbols,
+          mTokenNames,
+          mTokenSymbols,
+          reserveFactorPercents,
+          protocolSeizeSharePercents,
+          collateralFactorPercents,
+          mTokenDeployResults.map((deployResult) => { return deployResult.contractAddress }),
+        )
+  } finally {
+      // Kill our child chain.
+      console.log("Shutting down Ganache chain. PID", forkedChainProcess.pid!)
+      process.kill(-forkedChainProcess.pid!)
+      console.log("Ganache chain stopped.")
+  }
+});
+
+test("market-deployer with 3 markets", async () => {
+  const contracts = Contracts.moonbeam
+
+  const fGLMRLM = '0x6972f25AB3FC425EaF719721f0EBD1Cdb58eE451'
+  const cGLMRAPPDEV = '0x519ee031E182D3E941549E7909C9319cFf4be69a'
+
+  const forkedChainProcess = await startGanache(
+      contracts,
+      FORK_BLOCK,
+      'https://rpc.api.moonbeam.network',
+      [fGLMRLM, cGLMRAPPDEV]
+  )
+
+  console.log("Waiting 5 seconds for chain to bootstrap...")
+  await sleep(5)
+
+  try {
+        const tokensToList = [
+          "0x27292cf0016e5df1d8b37306b2a98588acbd6fca", 
+          "0xca01a1d0993565291051daff390892518acfad3a",
+          "0x61C82805453a989E99B544DFB7031902e9bac448",
+        ]
+        const chainlinkAddresses = [
+          "0x4F152D143c97B5e8d2293bc5B2380600f274a5dd", 
+          "0xA122591F60115D63421f66F752EF9f6e0bc73abC",
+          "0x05Ec3Fb5B7CB3bE9D7150FBA1Fb0749407e5Aa8a",
+        ]
+        const tokenSymbols = [
+          "axlATOM", 
+          "axlUSDC",
+          "axlFRAX",
+        ]
+        const tokenDecimals = [6, 6, 18]
+        const mTokenNames = ["Moonwell axlATOM", "Moonwell AXL USDC", "Moonwell AXL FRAX"]
+        const mTokenSymbols = ["maxlATOM", "maxlUSDC", "maxlFRAX"]
+        const reserveFactorPercents = [60, 65, 70]
+        const protocolSeizeSharePercents = [10, 15, 20]
+        const collateralFactorPercents = [40, 45, 50]
+
+        const provider = new ethers.providers.JsonRpcProvider('http://127.0.0.1:8545')
+
+        // Go transfer WELL to the deployer key, delegate those well to itself, and assert it has voting power
+        await setupDeployerAndEnvForGovernance(contracts, provider, wellTreasuryAddress, FORK_BLOCK)
+
+        // Assert that a market is not listed for the token and a chainlink feed is not registered.
+        await assertCurrentExpectedState(provider, contracts, tokensToList, chainlinkAddresses)
+
+        // Generate proposal data
+        const deployer = await provider.getSigner(0)
+        const {proposal, mTokenDeployResults} = await generateProposalData(
+          deployer,
+          tokensToList,
+          chainlinkAddresses,
+          tokenSymbols,
+          tokenDecimals,
+          mTokenNames,
+          mTokenSymbols,
+          reserveFactorPercents,
+          protocolSeizeSharePercents,
+          collateralFactorPercents,
+        )
+
+        // Pass the proposal
+        await passGovProposal(contracts, provider, proposal)
+
+        // Assert the market is correctly admin'ed, with the right economic parameters and has the right storage set.
+        // Assert that a chainlink feed has been registered.
+        await assertExpectedEndState(
+          provider,
+          contracts, 
+          tokensToList,
+          chainlinkAddresses,
+          tokenSymbols,
+          mTokenNames,
+          mTokenSymbols,
+          reserveFactorPercents,
+          protocolSeizeSharePercents,
+          collateralFactorPercents,
+          mTokenDeployResults.map((deployResult) => { return deployResult.contractAddress }),
         )
   } finally {
       // Kill our child chain.


### PR DESCRIPTION
- Pull in market-deployer@0.2.0 - which lets us deploy multiple markets at once
- Fork unit tests to test deploying 1 market and 3 markets